### PR TITLE
Switch to conversation dataset

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,7 +9,7 @@ block_size = 64
 device = 'cuda' if torch.cuda.is_available() else 'cpu'
 
 # Load tokenizer and model
-_, tokenizer = load_dataset("data/genz.txt", block_size=block_size)
+_, tokenizer = load_dataset("data/conversations.txt", block_size=block_size)
 
 model = TinyTransformer(
     vocab_size=tokenizer.vocab_size,
@@ -24,15 +24,17 @@ model.eval()
 
 # Generation function
 def genz_reply(message, history):
-    message = message.lower()  # normalize case
+    message = "User: " + message.lower()  # prefix with conversation tag
     encoded = tokenizer.encode(message)[-block_size:]
     idx = torch.tensor([encoded], dtype=torch.long).to(device)
 
     with torch.no_grad():
         out = model.generate(idx, max_new_tokens=150)[0]
 
-    response = tokenizer.decode(out)
-    return response
+    decoded = tokenizer.decode(out)
+    if "Bot:" in decoded:
+        decoded = decoded.split("Bot:", 1)[1]
+    return decoded.strip()
 
 
 # Launch Gradio chatbot interface

--- a/data/conversations.txt
+++ b/data/conversations.txt
@@ -1,0 +1,16 @@
+User: hey what's up?
+Bot: not much, just chilling. you?
+User: just hanging out.
+Bot: sounds like a vibe!
+User: tell me a joke.
+Bot: why did the scarecrow get promoted? because he was outstanding in his field.
+User: that's cringe lol
+Bot: nah it's peak comedy fr.
+User: do you play games?
+Bot: for sure, i grind all night long.
+User: cool same here
+Bot: let's squad up sometime.
+User: what's your favorite food?
+Bot: pizza all day, it's straight fire.
+User: see ya
+Bot: later skater!

--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -17,7 +17,7 @@ class CharTokenizer:
         return ''.join(self.itos[i] for i in ids if i in self.itos)
 
 
-def load_dataset(file_path, block_size=64):
+def load_dataset(file_path="data/conversations.txt", block_size=64):
     with open(file_path, 'r', encoding='utf-8') as f:
         text = f.read()
     tokenizer = CharTokenizer(text)

--- a/src/train.py
+++ b/src/train.py
@@ -16,7 +16,7 @@ learning_rate = 3e-4
 device = 'cuda' if torch.cuda.is_available() else 'cpu'
 
 # Load data and tokenizer
-data, tokenizer = load_dataset("data/genz.txt", block_size=block_size)
+data, tokenizer = load_dataset("data/conversations.txt", block_size=block_size)
 split = int(0.9 * len(data))
 train_data = data[:split]
 val_data = data[split:]


### PR DESCRIPTION
## Summary
- add a small `data/conversations.txt` dataset
- load the new dataset in `load_dataset` and training script
- update `app.py` to use conversation tokenizer and parse out `Bot:` replies

## Testing
- `pytest -q`
- `black --check .`
- `python3 src/train.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6848dd0f5ec0832686f2ccc07b38ac95